### PR TITLE
Feat/global error

### DIFF
--- a/src/main/java/com/askus/askus/domain/board/controller/BoardController.java
+++ b/src/main/java/com/askus/askus/domain/board/controller/BoardController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.askus.askus.domain.board.dto.BoardAddRequest;
 import com.askus.askus.domain.board.dto.BoardAddResponse;
 import com.askus.askus.domain.board.service.BoardService;
+import com.askus.askus.domain.users.security.SecurityUser;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,12 +25,11 @@ public class BoardController {
 
 	@PostMapping()
 	public ResponseEntity<BoardAddResponse> addBoard(
+		@AuthenticationPrincipal SecurityUser securityUser,
 		BoardAddRequest request
 	) throws IOException {
-		//TODO: @AuthenticationPrincipal 활용 -> SecurityUser 타입 Authentication 객체에서 userId 가져올 것
-		long id = 1L;
-
-		BoardAddResponse boardAddResponse = boardService.addBoard(id, request);
+		Long userId = securityUser.getId();
+		BoardAddResponse boardAddResponse = boardService.addBoard(userId, request);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
 			.body(boardAddResponse);

--- a/src/main/java/com/askus/askus/domain/board/controller/BoardController.java
+++ b/src/main/java/com/askus/askus/domain/board/controller/BoardController.java
@@ -1,12 +1,10 @@
 package com.askus.askus.domain.board.controller;
 
-import java.io.IOException;
-
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.askus.askus.domain.board.dto.BoardAddRequest;
@@ -24,14 +22,12 @@ public class BoardController {
 	private final BoardService boardService;
 
 	@PostMapping()
-	public ResponseEntity<BoardAddResponse> addBoard(
+	@ResponseStatus(HttpStatus.CREATED)
+	public BoardAddResponse addBoard(
 		@AuthenticationPrincipal SecurityUser securityUser,
 		BoardAddRequest request
-	) throws IOException {
+	) {
 		Long userId = securityUser.getId();
-		BoardAddResponse boardAddResponse = boardService.addBoard(userId, request);
-		return ResponseEntity
-			.status(HttpStatus.CREATED)
-			.body(boardAddResponse);
+		return boardService.addBoard(userId, request);
 	}
 }

--- a/src/main/java/com/askus/askus/domain/board/dto/BoardAddRequest.java
+++ b/src/main/java/com/askus/askus/domain/board/dto/BoardAddRequest.java
@@ -11,6 +11,7 @@ import com.askus.askus.domain.board.domain.Category;
 import com.askus.askus.domain.image.domain.Image;
 import com.askus.askus.domain.image.domain.ImageType;
 import com.askus.askus.domain.users.domain.Users;
+import com.askus.askus.global.error.exception.KookleRuntimeException;
 
 import lombok.Getter;
 
@@ -58,7 +59,7 @@ public class BoardAddRequest {
 			byte[] byteArray = file.getBytes();
 			byteArrayInputStream = new ByteArrayInputStream(byteArray);
 		} catch (IOException e) {
-			throw new RuntimeException(e); //TODO 글로벌 예외 처리
+			throw new KookleRuntimeException("이미지 파일 변환 실패", e);
 		}
 		return byteArrayInputStream;
 	}

--- a/src/main/java/com/askus/askus/domain/board/service/BoardService.java
+++ b/src/main/java/com/askus/askus/domain/board/service/BoardService.java
@@ -1,10 +1,8 @@
 package com.askus.askus.domain.board.service;
 
-import java.io.IOException;
-
 import com.askus.askus.domain.board.dto.BoardAddRequest;
 import com.askus.askus.domain.board.dto.BoardAddResponse;
 
 public interface BoardService {
-	BoardAddResponse addBoard(long id, BoardAddRequest request) throws IOException;
+	BoardAddResponse addBoard(long id, BoardAddRequest request);
 }

--- a/src/main/java/com/askus/askus/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/askus/askus/domain/board/service/BoardServiceImpl.java
@@ -1,6 +1,5 @@
 package com.askus.askus.domain.board.service;
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -14,6 +13,7 @@ import com.askus.askus.domain.image.domain.ImageType;
 import com.askus.askus.domain.image.service.ImageService;
 import com.askus.askus.domain.users.domain.Users;
 import com.askus.askus.domain.users.repository.UsersRepository;
+import com.askus.askus.global.error.exception.KookleRuntimeException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,9 +26,9 @@ public class BoardServiceImpl implements BoardService {
 	private final ImageService imageService;
 
 	@Override
-	public BoardAddResponse addBoard(long id, BoardAddRequest request) throws IOException {
+	public BoardAddResponse addBoard(long id, BoardAddRequest request) {
 		Users users = usersRepository.findById(id)
-			.orElseThrow(() -> new IllegalArgumentException("User not Found"));//TODO: 글로벌 예외 처리
+			.orElseThrow(() -> new KookleRuntimeException("존재하지 않는 사용자"));
 
 		Board board = boardRepository.save(request.toEntity(users));
 

--- a/src/main/java/com/askus/askus/domain/image/domain/Image.java
+++ b/src/main/java/com/askus/askus/domain/image/domain/Image.java
@@ -4,7 +4,6 @@ import com.askus.askus.domain.image.service.ImageUploader;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -32,12 +31,12 @@ public class Image {
     /* 파일명으로 부터 확장자 얻기 및 검증 */
     private String checkAndGetExtension(String filename) {
         String extension = StringUtils.substringAfterLast(filename, ".");
-        checkContains(extension, ACCEPTED_FILE_EXTENSIONS, "illegal file extension provided for image");
+        checkContains(extension, ACCEPTED_FILE_EXTENSIONS, "잘못된 파일 형식");
         return extension;
     }
 
     /* 도메인 서비스 ImageUploader 를 활용해 이미지 업로드 수행 */
-    public String uploadBy(ImageUploader imageUploader) throws IOException {
+    public String uploadBy(ImageUploader imageUploader) {
         return imageUploader.upload(this);
     }
 }

--- a/src/main/java/com/askus/askus/domain/image/service/ImageService.java
+++ b/src/main/java/com/askus/askus/domain/image/service/ImageService.java
@@ -1,6 +1,5 @@
 package com.askus.askus.domain.image.service;
 
-import java.io.IOException;
 import java.util.Map;
 
 import com.askus.askus.domain.board.domain.Board;
@@ -8,5 +7,5 @@ import com.askus.askus.domain.board.dto.BoardAddRequest;
 import com.askus.askus.domain.image.domain.ImageType;
 
 public interface ImageService {
-	Map<ImageType, Object> uploadBoardImage(Board board, BoardAddRequest request) throws IOException;
+	Map<ImageType, Object> uploadBoardImage(Board board, BoardAddRequest request);
 }

--- a/src/main/java/com/askus/askus/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/askus/askus/domain/image/service/ImageServiceImpl.java
@@ -1,6 +1,5 @@
 package com.askus.askus.domain.image.service;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,7 +21,7 @@ public class ImageServiceImpl implements ImageService{
 	private final BoardImageRepository boardImageRepository;
 
 	@Override
-	public Map<ImageType, Object> uploadBoardImage(Board board, BoardAddRequest request) throws IOException {
+	public Map<ImageType, Object> uploadBoardImage(Board board, BoardAddRequest request) {
 		HashMap<ImageType, Object> map = new HashMap<>();
 
 		String thumbnailImageUrl = request.getThumbnailImage().uploadBy(imageUploader);

--- a/src/main/java/com/askus/askus/domain/image/service/ImageUploader.java
+++ b/src/main/java/com/askus/askus/domain/image/service/ImageUploader.java
@@ -1,10 +1,8 @@
 package com.askus.askus.domain.image.service;
 
-import java.io.IOException;
-
 import com.askus.askus.domain.image.domain.Image;
 
 public interface ImageUploader {
-    String upload(Image image) throws IOException;
+    String upload(Image image);
     void delete(String filename);
 }

--- a/src/main/java/com/askus/askus/domain/users/controller/UsersController.java
+++ b/src/main/java/com/askus/askus/domain/users/controller/UsersController.java
@@ -20,15 +20,15 @@ public class UsersController {
 
     private final UsersService usersService;
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+/*    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(Exception.class)
     public ErrorResponse exceptionHandler(Exception e) {
-        return ErrorResponse.builder()
+        return new ErrorResponse()ErrorResponse.builder()
                 .title("Error")
                 .status("400")
                 .detail(e.getMessage())
                 .build();
-    }
+    }*/
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/askus/askus/global/error/ErrorResponse.java
+++ b/src/main/java/com/askus/askus/global/error/ErrorResponse.java
@@ -1,12 +1,33 @@
 package com.askus.askus.global.error;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.http.HttpStatus;
+
 import lombok.*;
 
-@Getter @Setter
-@AllArgsConstructor
-@Builder
+@Data
 public class ErrorResponse {
-    private String title;
-    private String status;
-    private String detail;
+    @NotNull
+    private final int code;
+    @NotNull
+    private final String title;
+    @NotNull
+    private final String message;
+
+    public ErrorResponse(HttpStatus httpStatus, Exception exception) {
+        this(
+            httpStatus.value(),
+            exception.getClass().getSimpleName(),
+            defaultIfNull(exception.getMessage(), "")
+        );
+    }
+
+    public ErrorResponse(int code, String title, String message) {
+        this.code = code;
+        this.title = title;
+        this.message = message;
+    }
 }

--- a/src/main/java/com/askus/askus/global/error/ErrorResponseWithMessage.java
+++ b/src/main/java/com/askus/askus/global/error/ErrorResponseWithMessage.java
@@ -1,0 +1,37 @@
+package com.askus.askus.global.error;
+
+import java.text.MessageFormat;
+
+import org.springframework.http.HttpStatus;
+
+import com.askus.askus.global.error.exception.KookleRuntimeException;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorResponseWithMessage {
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	SIGNUP_BAD_REQUEST(HttpStatus.BAD_REQUEST, "이메일 혹은 비밀번호의 형식이 올바르지 않습니다."),
+	INVALID_FIELD(HttpStatus.BAD_REQUEST, "{0}의 형식이 올바르지 않습니다.");
+
+	private final HttpStatus status;
+	private final String title;
+	private final String message;
+
+	ErrorResponseWithMessage(HttpStatus status, String message) {
+		this(status, message, KookleRuntimeException.class);
+	}
+
+	ErrorResponseWithMessage(HttpStatus status, String message, Class<?> clazz) {
+		this.status = status;
+		this.title = clazz.getSimpleName();
+		this.message = message;
+	}
+
+	public ErrorResponse toInstance(Object[] args) {
+		String formattedMessage = MessageFormat.format(message, args);
+		return new ErrorResponse(status.value(), title, formattedMessage);
+	}
+}

--- a/src/main/java/com/askus/askus/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/askus/askus/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.askus.askus.global.error;
+
+import static org.apache.commons.lang3.ObjectUtils.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(RuntimeException.class)
+	public ErrorResponse handlerRuntimeException(Exception e) {
+		log.info(messageIfNull(e.getMessage()), e);
+		return new ErrorResponse(HttpStatus.BAD_REQUEST, e);
+	}
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(NoHandlerFoundException.class)
+	public ErrorResponse noHandlerFoundException(Exception e) {
+		return new ErrorResponse(HttpStatus.NOT_FOUND, e);
+	}
+
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler(Exception.class)
+	public ErrorResponse handlerException(Exception e) {
+		log.error(messageIfNull(e.getMessage()), e);
+		return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e);
+	}
+
+	private String messageIfNull(String message) {
+		return defaultIfNull(message, "exception with no message");
+	}
+}

--- a/src/main/java/com/askus/askus/global/error/exception/KookleRuntimeException.java
+++ b/src/main/java/com/askus/askus/global/error/exception/KookleRuntimeException.java
@@ -1,0 +1,30 @@
+package com.askus.askus.global.error.exception;
+
+/**
+ * Root RuntimeException for this Application
+ */
+public class KookleRuntimeException extends RuntimeException {
+	public KookleRuntimeException() {
+	}
+
+	public KookleRuntimeException(String message) {
+		super(message);
+	}
+
+	public KookleRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public KookleRuntimeException(Throwable cause) {
+		super(cause);
+	}
+
+	public KookleRuntimeException(
+		String message,
+		Throwable cause,
+		boolean enableSuppression,
+		boolean writableStackTrace)
+	{
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}


### PR DESCRIPTION
- 글로번 예외 처리 코드 추가
- Board 등록 API 응답 수정 

** 글로벌 예외처리 코드 추가해보았는데, 리뷰 부탁드립니다!!:cry:
예외처리는 왜 해도 어려울까요..

** ResponseEntity 사용하는 것보다 한동님께서 사용하는 방식이 훨씬 깔끔한 것 같아서 수정했는데 찾다보니
[이 글: ResponseEntity vs @ResponseStatus](https://joojimin.tistory.com/54) 한 번 참고해서 저희도 어떤 방향으로 통일하면 좋을 것 같아요:)